### PR TITLE
Orders, OrderRows and FiscalTransactionSignatures

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 namespace CCVShop\Api;
 
 use CCVShop\Api\Endpoints\Credentials;
+use CCVShop\Api\Endpoints\FiscalTransactionSignatures;
+use CCVShop\Api\Endpoints\OrderRows;
 use CCVShop\Api\Endpoints\Webhooks;
 use CCVShop\Api\Endpoints\Webshops;
 use CCVShop\Api\Endpoints\Merchant;
 use CCVShop\Api\Endpoints\Apps;
+use CCVShop\Api\Endpoints\Orders;
 
 class ApiClient
 {
@@ -21,6 +24,9 @@ class ApiClient
     public Webshops $webshops;
     public Apps $apps;
     public Webhooks $webhooks;
+    public Orders $orders;
+    public OrderRows $orderRows;
+    public FiscalTransactionSignatures $fiscalTransactionSignatures;
 
     /**
      * @param string|null $hostName Fallback in .env['CCVSHOP_API_HOSTNAME']
@@ -35,10 +41,13 @@ class ApiClient
             $apiSecret ?? $_ENV['CCVSHOP_API_SECRET']
         );
 
-        $this->credentials = new Credentials($this);
-        $this->merchant    = new Merchant($this);
-        $this->webshops    = new Webshops($this);
-        $this->apps        = new Apps($this);
-        $this->webhooks    = new Webhooks($this);
+        $this->credentials                  = new Credentials($this);
+        $this->merchant                     = new Merchant($this);
+        $this->webshops                     = new Webshops($this);
+        $this->apps                         = new Apps($this);
+        $this->webhooks                     = new Webhooks($this);
+        $this->orders                       = new Orders($this);
+        $this->orderRows                    = new OrderRows($this);
+        $this->fiscalTransactionSignatures  = new FiscalTransactionSignatures($this);
     }
 }

--- a/src/BaseEndpoint.php
+++ b/src/BaseEndpoint.php
@@ -46,7 +46,6 @@ abstract class BaseEndpoint
      * @param array $filters
      *
      * @return BaseResource
-     * @throws GuzzleException
      * @throws InvalidHashOnResult
      * @throws InvalidResponseException
      * @throws \JsonException

--- a/src/BaseResource.php
+++ b/src/BaseResource.php
@@ -6,6 +6,7 @@ namespace CCVShop\Api;
 abstract class BaseResource
 {
     protected ApiClient $client;
+    public array $dates = [];
 
     abstract public function getEndpoint(): BaseEndpoint;
 

--- a/src/Endpoints/FiscalTransactionSignatures.php
+++ b/src/Endpoints/FiscalTransactionSignatures.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace CCVShop\Api\Endpoints;
+
+use CCVShop\Api\BaseEndpoint;
+use CCVShop\Api\BaseResource;
+use CCVShop\Api\Exceptions\InvalidHashOnResult;
+use CCVShop\Api\Factory\ResourceFactory;
+use CCVShop\Api\Interfaces\Endpoints\Get;
+use CCVShop\Api\Interfaces\Endpoints\GetAll;
+use CCVShop\Api\Interfaces\Endpoints\Patch;
+use CCVShop\Api\Interfaces\Endpoints\Post;
+use CCVShop\Api\Resources\FiscalTransactionSignature;
+use CCVShop\Api\Resources\FiscalTransactionSignatureCollection;
+use CCVShop\Api\Resources\Order;
+
+class FiscalTransactionSignatures extends BaseEndpoint implements
+    Get,
+    GetAll,
+    Post,
+    Patch
+{
+    protected string $resourcePath = 'fiscaltransactionsignatures';
+    protected ?string $parentResourcePath = 'orders';
+
+    /**
+     * @description Get the resource object
+     * @return FiscalTransactionSignature;
+     */
+    protected function getResourceObject(): FiscalTransactionSignature
+    {
+        return new FiscalTransactionSignature($this->client);
+    }
+
+    /**
+     * @description Get the resource collection object
+     * @return FiscalTransactionSignatureCollection
+     */
+    protected function getResourceCollectionObject(): FiscalTransactionSignatureCollection
+    {
+        return new FiscalTransactionSignatureCollection();
+    }
+
+    /**
+     * @description Get one by id
+     * @param int $id
+     * @return FiscalTransactionSignature
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function get(int $id): FiscalTransactionSignature
+    {
+        /** @var FiscalTransactionSignature $result */
+        $result = $this->rest_getOne($id, []);
+
+        return $result;
+    }
+
+
+    /**
+     * @description Get all fiscal transaction signatures by order resource.
+     * @param Order $order
+     * @param array $parameters
+     * @return FiscalTransactionSignatureCollection
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function getFor(Order $order, array $parameters = []): FiscalTransactionSignatureCollection
+    {
+        $this->setParent(ResourceFactory::createParentFromResource($order));
+        /** @var FiscalTransactionSignatureCollection $result */
+        $result = $this->rest_getAll(null, null, $parameters);
+
+        return $result;
+    }
+
+    /**
+     * @description Get all by parameters
+     * @param array $parameters
+     * @return FiscalTransactionSignatureCollection
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function getAll(array $parameters = []): FiscalTransactionSignatureCollection
+    {
+        /** @var FiscalTransactionSignatureCollection $result */
+        $result = $this->rest_getAll(null, null, $parameters);
+
+        return $result;
+    }
+
+    /**
+     * @description Post a fiscal transaction signature.
+     * @param FiscalTransactionSignature|null $signature
+     * @return BaseResource|FiscalTransactionSignatures
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function post(int $orderId = null, FiscalTransactionSignature $signature = null): \CCVShop\Api\Resources\FiscalTransactionSignature
+    {
+        if ($orderId === null) {
+            throw new \InvalidArgumentException('order id is required');
+        }
+
+        $this->setParent(ResourceFactory::createParent($this->client->orders->getResourcePath(), $orderId));
+
+        if ($signature === null) {
+            throw new \InvalidArgumentException(FiscalTransactionSignature::class . ' required');
+        }
+
+        return $this->rest_post([
+            'create_date' => $signature->create_date,
+            'type' => $signature->type,
+            'signature_identifier' => $signature->signature_identifier,
+            'signature_data' => $signature->signature_data
+        ]);
+    }
+
+    /**
+     * @description Patch a fiscal transaction signature.
+     * @param FiscalTransactionSignature|null $signature
+     * @return void
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function patch(FiscalTransactionSignature $signature = null): void
+    {
+        if ($signature === null) {
+            throw new \InvalidArgumentException(FiscalTransactionSignature::class . ' required');
+        }
+
+        $this->rest_patch($signature->id, [
+            'signature_data' => $signature->signature_data
+        ]);
+    }
+}

--- a/src/Endpoints/OrderRows.php
+++ b/src/Endpoints/OrderRows.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CCVShop\Api\Endpoints;
+
+use CCVShop\Api\BaseEndpoint;
+use CCVShop\Api\Exceptions\InvalidHashOnResult;
+use CCVShop\Api\Factory\ResourceFactory;
+use CCVShop\Api\Interfaces\Endpoints\Get;
+use CCVShop\Api\Resources\Order;
+use CCVShop\Api\Resources\OrderRow;
+use CCVShop\Api\Resources\OrderRowCollection;
+
+class OrderRows extends BaseEndpoint implements Get
+{
+    protected string $resourcePath = 'orderrows';
+    protected ?string $parentResourcePath = 'orders';
+
+    /**
+     * @return OrderRow
+     */
+    protected function getResourceObject(): OrderRow
+    {
+       return new OrderRow($this->client);
+    }
+
+    /**
+     * @return OrderRowCollection
+     */
+    protected function getResourceCollectionObject(): OrderRowCollection
+    {
+        return new OrderRowCollection();
+    }
+
+    /**
+     * @description Get one by id
+     * @param int $id
+     * @return OrderRow
+     * @throws \CCVShop\Api\Exceptions\InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function get(int $id): OrderRow
+    {
+        /** @var OrderRow $result */
+        $result = $this->rest_getOne($id, []);
+
+        return $result;
+    }
+
+    /**
+     * @description Get all order rows by order resource.
+     * @param Order $order
+     * @param array $parameters
+     * @return OrderRowCollection
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function getFor(Order $order, array $parameters = []): OrderRowCollection
+    {
+        $this->setParent(ResourceFactory::createParentFromResource($order));
+        /** @var OrderRowCollection $result */
+        $result = $this->rest_getAll(null, null, $parameters);
+
+        return $result;
+    }
+}

--- a/src/Endpoints/Orders.php
+++ b/src/Endpoints/Orders.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CCVShop\Api\Endpoints;
+
+use CCVShop\Api\BaseEndpoint;
+use CCVShop\Api\BaseResource;
+use CCVShop\Api\BaseResourceCollection;
+use CCVShop\Api\Exceptions\InvalidHashOnResult;
+use CCVShop\Api\Interfaces\Endpoints\Get;
+use CCVShop\Api\Resources\Order;
+use CCVShop\Api\Resources\OrderCollection;
+
+class Orders extends BaseEndpoint implements Get
+{
+    protected string $resourcePath = 'orders';
+
+    /**
+     * @return BaseResource
+     */
+    protected function getResourceObject(): Order
+    {
+        return new Order($this->client);
+    }
+
+    /**
+     * @return BaseResourceCollection
+     */
+    protected function getResourceCollectionObject(): OrderCollection
+    {
+        return new OrderCollection();
+    }
+
+    /**
+     * @description Get one by id
+     * @param int $id
+     * @return Order
+     * @throws InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function get(int $id): Order
+    {
+        /** @var Order $result */
+        $result = $this->rest_getOne($id, []);
+
+        return $result;
+    }
+}

--- a/src/Factory/ResourceFactory.php
+++ b/src/Factory/ResourceFactory.php
@@ -12,7 +12,12 @@ class ResourceFactory
             if (!property_exists($resource, $property)) {
                 continue;
             }
-            $resource->{$property} = $value;
+
+            if (!empty($resource->dates) && in_array($property, $resource->dates) && !empty($value)) {
+                $resource->{$property} = new \DateTime($value);
+            } else {
+                $resource->{$property} = $value;
+            }
         }
 
         return $resource;

--- a/src/Resources/App.php
+++ b/src/Resources/App.php
@@ -12,8 +12,8 @@ class App extends BaseResource
     public ?string $name = null;
     public ?\stdClass $eur_prices = null;
     public ?\stdClass $chf_prices = null;
-    public ?string $create_date = null;
-    public ?string $modified_date = null;
+    public ?\DateTime $create_date = null;
+    public ?\DateTime $modified_date = null;
     public ?string $description = null;
     public ?string $cover = null;
     public ?string $logo = null;
@@ -25,6 +25,8 @@ class App extends BaseResource
     public ?\stdClass $categories = null;
     public ?\stdClass $code_blocks = null;
     public ?\stdClass $psp = null;
+
+    public array $dates = ['create_date', 'modified_date'];
 
     public function getEndpoint(): Apps
     {

--- a/src/Resources/FiscalTransactionSignature.php
+++ b/src/Resources/FiscalTransactionSignature.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CCVShop\Api\Resources;
+
+use CCVShop\Api\BaseResource;
+use CCVShop\Api\Endpoints\FiscalTransactionSignatures;
+
+class FiscalTransactionSignature extends BaseResource
+{
+    public ?int $id = null;
+    public ?string $href = null;
+    public ?\DateTime $create_date = null;
+    public ?string $signature_identifier = null;
+    public ?string $type = null;
+    public ?string $signature_data = null;
+
+    public array $dates = ['create_date'];
+
+    public function getEndpoint(): FiscalTransactionSignatures
+    {
+        return $this->client->fiscalTransactionSignatures;
+    }
+}

--- a/src/Resources/FiscalTransactionSignatureCollection.php
+++ b/src/Resources/FiscalTransactionSignatureCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CCVShop\Api\Resources;
+
+use CCVShop\Api\BaseResourceCollection;
+
+class FiscalTransactionSignatureCollection extends BaseResourceCollection
+{
+
+}

--- a/src/Resources/Order.php
+++ b/src/Resources/Order.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace CCVShop\Api\Resources;
+
+use CCVShop\Api\ApiClient;
+use CCVShop\Api\BaseResource;
+
+class Order extends BaseResource
+{
+    public ?int $id = null;
+    public ?string $href = null;
+    public ?string $ordernumber_prefix = null;
+    public ?int $ordernumber = null;
+    public ?string $ordernumber_full = null;
+    public ?int $invoicenumber = null;
+    public ?string $transaction_id = null;
+    public ?\DateTime $create_date = null;
+    public ?string $deliver_method = null;
+    public ?\DateTime $deliver_date = null;
+    public ?\stdClass $take_out_window = null;
+    public ?bool $is_platform_sale = null;
+    public ?string $orderedinlng = null;
+    public ?int $status = null;
+    public ?bool $is_completed = null;
+    public ?string $basket_href = null;
+    public ?string $checkout_href = null;
+    public ?bool $paid = null;
+    public ?bool $safety_deposit_returned = null;
+    public ?int $paymethod_id = null;
+    public ?string $paymethod = null;
+    public ?string $paymethod_label = null;
+    public ?bool $taxes_included = null;
+    public ?bool $order_row_taxes_included = null;
+    public ?bool $shipping_taxes_included = null;
+    public ?float $shipping_tax_percentage = null;
+    public ?bool $is_intra_community_order = null;
+    public ?float $total_orderrow_price = null;
+    public ?float $total_shipping = null;
+    public ?float $total_discounts = null;
+    public ?float $total_price = null;
+    public ?string $currency = null;
+    public ?float $total_tax = null;
+    public ?float $total_weight = null;
+    public ?string $extra_payment_option = null;
+    public ?float $extra_payment_option_price = null;
+    public ?bool $extra_payment_option_no_sentprice = null;
+    public ?bool $extra_payment_option_pay_on_pickup = null;
+    public ?float $extra_price = null;
+    public ?float $paymethod_costs = null;
+    public ?float $credit_point_discount = null;
+    public ?float $extra_costs = null;
+    public ?string $extra_costs_description = null;
+    public ?string $track_and_trace_code = null;
+    public ?string $track_and_trace_carrier = null;
+    public ?string $track_and_trace_deeplink = null;
+    public ?string $reservationnumber = null;
+    public ?string $delivery_option = null;
+
+    public ?\stdClass $user = null;
+
+    public ?\stdClass $discountcoupon = null;
+
+    public ?\stdClass $customer = null;
+
+    public ?\stdClass $pickup_address = null;
+    public ?string $packing_slip_deeplink = null;
+
+    public ?\stdClass $orderrows = null;
+
+    public ?\stdClass $ordernotes = null;
+
+    public ?\stdClass $ordermessages = null;
+
+    public ?\stdClass $ordernotifications = null;
+
+    public ?\stdClass $orderaffiliatenetworks = null;
+
+    public ?\stdClass $orderlabels = null;
+
+    public ?\stdClass $terminalreceipts = null;
+
+    public ?\stdClass $fiscaltransactionsignatures = null;
+
+    public ?\stdClass $invoices = null;
+
+    public array $dates = ['create_date', 'deliver_date'];
+
+    /**
+     * @return \CCVShop\Api\Endpoints\Orders
+     */
+    public function getEndpoint(): \CCVShop\Api\Endpoints\Orders
+    {
+        return $this->client->orders;
+    }
+
+    /**
+     * @description Retrieve the fiscal transaction signatures of the current order.
+     * @return FiscalTransactionSignatureCollection
+     * @throws \CCVShop\Api\Exceptions\InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function getFiscalTransactionSignatures(): FiscalTransactionSignatureCollection
+    {
+        return $this->client->fiscalTransactionSignatures->getFor($this);
+    }
+
+    /**
+     * @description Retrieve the order rows of the current order.
+     * @return OrderRowCollection
+     * @throws \CCVShop\Api\Exceptions\InvalidHashOnResult
+     * @throws \CCVShop\Api\Exceptions\InvalidResponseException
+     * @throws \JsonException
+     */
+    public function getOrderRows(): OrderRowCollection
+    {
+        return $this->client->orderRows->getFor($this);
+    }
+}

--- a/src/Resources/OrderCollection.php
+++ b/src/Resources/OrderCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CCVShop\Api\Resources;
+
+use CCVShop\Api\BaseResourceCollection;
+
+class OrderCollection extends BaseResourceCollection
+{
+
+}

--- a/src/Resources/OrderRow.php
+++ b/src/Resources/OrderRow.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace CCVShop\Api\Resources;
+
+use CCVShop\Api\BaseResource;
+use CCVShop\Api\Endpoints\OrderRows;
+
+class OrderRow extends BaseResource
+{
+    public ?string $href;
+    public ?int $id;
+    public ?int $order_id;
+    public ?string $product_type;
+    public ?string $product_name;
+    public ?string $product_name_google;
+    public ?string $product_number;
+    public ?string $sub_product_number;
+    public ?string $sub_sku_number;
+    public ?string $sub_ean_number;
+    public ?int $product_id;
+    public ?string $product_href;
+    public ?float $count;
+    public ?float $price;
+    public ?float $product_purchase_price;
+    public ?float $discount;
+    public ?bool $custom_price;
+    public ?float $tax;
+    public ?string $unit;
+    public ?float $weight;
+    public ?string $memo;
+
+    public ?int $package_id;
+    public ?string $package_name;
+    public ?string $stock_location;
+    public ?string $supplier;
+    public ?float $user_discount;
+    public ?float $original_price;
+    public ?float $selling_price;
+    public ?float $price_without_discount;
+    public ?float $price_without_discount_with_attributes;
+    public ?float $total_price;
+    public ?float $total_extra_option_price;
+    public ?float $price_with_attributes;
+    public ?float $total_price_with_attributes;
+    public ?string $calculator_href;
+    public ?array $attributes;
+    public ?array $uploads;
+    public ?\stdClass $parent;
+
+    /**
+     * @return OrderRows
+     */
+    public function getEndpoint(): OrderRows
+    {
+        return $this->client->orderrows;
+    }
+}

--- a/src/Resources/OrderRowCollection.php
+++ b/src/Resources/OrderRowCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CCVShop\Api\Resources;
+
+use CCVShop\Api\BaseResourceCollection;
+
+class OrderRowCollection extends BaseResourceCollection
+{
+
+}

--- a/src/Resources/Webhook.php
+++ b/src/Resources/Webhook.php
@@ -9,11 +9,13 @@ class Webhook extends BaseResource
 {
     public ?int $id = null;
     public ?string $href = null;
-    public ?string $createdate = null;
+    public ?\DateTime $createdate = null;
     public ?string $event = null;
     public ?string $address = null;
     public ?string $key = null;
     public ?bool $is_active = null;
+
+    public array $dates = ['createdate'];
 
     public function getEndpoint(): Webhooks
     {


### PR DESCRIPTION
With this pull request the following resources will be added to the SDK package.

- Orders (base, not all functionalities).
- OrderRows (base, not all functionalities).
- FiscalTransactionSignatures.

Next to that, the "date" fields, will now return a `\DateTime` object instead of a string.